### PR TITLE
[docs] update old pdftron site to apryse

### DIFF
--- a/Golang_Building_Guide.txt
+++ b/Golang_Building_Guide.txt
@@ -13,7 +13,7 @@ This document shows a simple guide on how to build Golang bindings of PDFNet for
 
 # Build Instructions
 
-1. Download the correct PDFNetC64 for your version from https://www.pdftron.com/nightly, place this in the root directory of this project and **ensure it is named according to the operating system**.
+1. Download the correct PDFNetC64 for your version from https://dev.apryse.com/nightly, place this in the root directory of this project and **ensure it is named according to the operating system**.
 
 Windows > PDFNetC64.zip
 Mac     > PDFNetCMac.zip

--- a/Golang_Building_Guide.txt
+++ b/Golang_Building_Guide.txt
@@ -3,7 +3,7 @@ This document shows a simple guide on how to build Golang bindings of PDFNet for
 # Required Dependencies:
 - This repository
 - CMake: http://www.cmake.org/download/ (version 2.8+)
-- The correct PDFNetC64 for your build: https://www.apryse.com/downloads/PDFNetC64.zip (Windows)
+- The correct PDFNetC64 for your build: https://www.pdftron.com/downloads/PDFNetC64.zip (Windows)
 - SWIG https://www.swig.org/download.html
 - Python3+
 - Go 1.15+

--- a/PDFTronGo/README.md
+++ b/PDFTronGo/README.md
@@ -3,7 +3,7 @@
   <p>
   </p>
   <h3>
-    <a href="https://www.pdftron.com/documentation/go/">Website</a>
+    <a href="https://docs.apryse.com/documentation/core/guides/?language=go">Website</a>
   </h3>
 </div>
 <hr/>

--- a/PHP_Building_Guide_for_Windows.txt
+++ b/PHP_Building_Guide_for_Windows.txt
@@ -4,7 +4,7 @@ This document shows a simple guide on how to build PHP bindings of PDFNet for Wi
 
 2. Because we just obtained x86 of PHP, we want to also obtain the required PDFNetC which must be 32-bit as well: https://www.pdftron.com/downloads/PDFNetC.zip (For x64, please obtain `PDFNetC64` from https://www.pdftron.com/downloads/PDFNetC64.zip) 
 
-3. Download the Github repository for the wrappers: https://github.com/PDFTron/PDFNetWrappers/archive/master.zip
+3. Download the Github repository for the wrappers: https://github.com/ApryseSDK/PDFNetWrappers/archive/master.zip
 
 4. Download and install CMake: http://www.cmake.org/download/ (it does not matter which version)
 

--- a/Samples/AdvancedImagingTest/PYTHON/AdvancedImagingTest.py
+++ b/Samples/AdvancedImagingTest/PYTHON/AdvancedImagingTest.py
@@ -35,7 +35,7 @@ def main():
         Unable to run AdvancedImaging2PDFTest: PDFTron SDK Advanced Imaging module not available.
         ---------------------------------------------------------------
         The Advanced Imaging module is an optional add-on, available for download
-        at http://www.pdftron.com/. If you have already downloaded this
+        at https://dev.apryse.com/. If you have already downloaded this
         module, ensure that the SDK is able to find the required files
         using the PDFNet::AddResourceSearchPath() function.""")
 

--- a/Samples/CAD2PDFTest/GO/CAD2PDF_test.go
+++ b/Samples/CAD2PDFTest/GO/CAD2PDF_test.go
@@ -42,7 +42,7 @@ func TestCAD2PDF(t *testing.T){
         fmt.Println("Unable to run CAD2PDFTest: PDFTron SDK CAD module not available.\n" +
         "---------------------------------------------------------------\n" +
         "The CAD module is an optional add-on, available for download\n" +
-        "at http://www.pdftron.com/. If you have already downloaded this\n" +
+        "at https://dev.apryse.com/. If you have already downloaded this\n" +
         "module, ensure that the SDK is able to find the required files\n" +
         "using the PDFNet::AddResourceSearchPath() function.")
 

--- a/Samples/CAD2PDFTest/PHP/CAD2PDFTest.php
+++ b/Samples/CAD2PDFTest/PHP/CAD2PDFTest.php
@@ -27,7 +27,7 @@ $output_path = getcwd()."/../../TestFiles/Output/";
 		echo "Unable to run CAD2PDFTest: PDFTron SDK CAD module not available.\n
 			---------------------------------------------------------------\n
 			The CAD module is an optional add-on, available for download\n
-			at http://www.pdftron.com/. If you have already downloaded this\n
+			at https://dev.apryse.com/. If you have already downloaded this\n
 			module, ensure that the SDK is able to find the required files\n
 			using the PDFNet::AddResourceSearchPath() function.\n";
 	} else

--- a/Samples/CAD2PDFTest/PYTHON/CAD2PDFTest.py
+++ b/Samples/CAD2PDFTest/PYTHON/CAD2PDFTest.py
@@ -35,7 +35,7 @@ def main():
         Unable to run CAD2PDFTest: PDFTron SDK CAD module not available.
         ---------------------------------------------------------------
         The CAD module is an optional add-on, available for download
-        at http://www.pdftron.com/. If you have already downloaded this
+        at https://dev.apryse.com/. If you have already downloaded this
         module, ensure that the SDK is able to find the required files
         using the PDFNet::AddResourceSearchPath() function.""")
 

--- a/Samples/CAD2PDFTest/RUBY/CAD2PDFTest.rb
+++ b/Samples/CAD2PDFTest/RUBY/CAD2PDFTest.rb
@@ -30,7 +30,7 @@ output_path = "../../TestFiles/Output/"
 			puts 'Unable to run CAD2PDFTest: PDFTron SDK CAD module not available.'
 			puts '---------------------------------------------------------------'
 			puts 'The CAD module is an optional add-on, available for download'
-			puts 'at http://www.pdftron.com/. If you have already downloaded this'
+			puts 'at https://dev.apryse.com/. If you have already downloaded this'
 			puts 'module, ensure that the SDK is able to find the required files'
 			puts 'using the PDFNet::AddResourceSearchPath() function.'
 		else

--- a/Samples/HTML2PDFTest/GO/HTML2PDF_test.go
+++ b/Samples/HTML2PDFTest/GO/HTML2PDF_test.go
@@ -26,7 +26,7 @@ func init() {
 // 'pdftron.PDF.HTML2PDF' is an optional PDFNet Add-On utility class that can be 
 // used to convert HTML web pages into PDF documents by using an external module (html2pdf).
 //
-// html2pdf modules can be downloaded from http://www.pdftron.com/pdfnet/downloads.html.
+// html2pdf modules can be downloaded from https://dev.apryse.com/.
 //
 // Users can convert HTML pages to PDF using the following operations:
 // - Simple one line static method to convert a single web page to PDF. 
@@ -56,7 +56,7 @@ func TestHTM2PDF(t *testing.T){
         fmt.Println("Unable to run HTML2PDFTest: PDFTron SDK HTML2PDF module not available.\n" +
         "---------------------------------------------------------------\n" +
         "The HTML2PDF module is an optional add-on, available for download\n" +
-        "at http://www.pdftron.com/. If you have already downloaded this\n" +
+        "at https://dev.apryse.com/. If you have already downloaded this\n" +
         "module, ensure that the SDK is able to find the required files\n" +
         "using the HTML2PDF::SetModulePath() function.")
         return

--- a/Samples/HTML2PDFTest/PHP/HTML2PDFTest.php
+++ b/Samples/HTML2PDFTest/PHP/HTML2PDFTest.php
@@ -18,7 +18,7 @@ $output_path = $input_path."Output/";
 // 'pdftron.PDF.HTML2PDF' is an optional PDFNet Add-On utility class that can be 
 // used to convert HTML web pages into PDF documents by using an external module (html2pdf).
 //
-// html2pdf modules can be downloaded from http://www.pdftron.com/pdfnet/downloads.html.
+// html2pdf modules can be downloaded from https://dev.apryse.com/.
 //
 // Users can convert HTML pages to PDF using the following operations:
 // - Simple one line static method to convert a single web page to PDF. 

--- a/Samples/HTML2PDFTest/RUBY/HTML2PDFTest.rb
+++ b/Samples/HTML2PDFTest/RUBY/HTML2PDFTest.rb
@@ -45,7 +45,7 @@ $stdout.sync = true
 		puts 'Unable to run HTML2PDFTest: PDFTron SDK HTML2PDF module not available.'
 		puts '---------------------------------------------------------------'
 		puts 'The HTML2PDF module is an optional add-on, available for download'
-		puts 'at http://www.pdftron.com/. If you have already downloaded this'
+		puts 'at https://dev.apryse.com/. If you have already downloaded this'
 		puts 'module, ensure that the SDK is able to find the required files'
 		puts 'using the HTML2PDF.SetModulePath function.'
 		return 

--- a/Samples/OCRTest/GO/OCR_test.go
+++ b/Samples/OCRTest/GO/OCR_test.go
@@ -42,7 +42,7 @@ func TestOCR(t *testing.T){
         fmt.Println("Unable to run OCRTest: PDFTron SDK OCR module not available.\n" +
         "---------------------------------------------------------------\n" +
         "The OCR module is an optional add-on, available for download\n" +
-        "at http://www.pdftron.com/. If you have already downloaded this\n" +
+        "at https://dev.apryse.com/. If you have already downloaded this\n" +
         "module, ensure that the SDK is able to find the required files\n" +
         "using the PDFNet::AddResourceSearchPath() function.")
 

--- a/Samples/OCRTest/PHP/OCRTest.php
+++ b/Samples/OCRTest/PHP/OCRTest.php
@@ -27,7 +27,7 @@ $output_path = getcwd()."/../../TestFiles/Output/";
 		echo "Unable to run OCRTest: PDFTron SDK OCR module not available.\n
 			---------------------------------------------------------------\n
 			The OCR module is an optional add-on, available for download\n
-			at http://www.pdftron.com/. If you have already downloaded this\n
+			at https://dev.apryse.com/. If you have already downloaded this\n
 			module, ensure that the SDK is able to find the required files\n
 			using the PDFNet::AddResourceSearchPath() function.\n";
 	} else

--- a/Samples/OCRTest/PYTHON/OCRTest.py
+++ b/Samples/OCRTest/PYTHON/OCRTest.py
@@ -35,7 +35,7 @@ def main():
         Unable to run OCRTest: PDFTron SDK OCR module not available.
         ---------------------------------------------------------------
         The OCR module is an optional add-on, available for download
-        at http://www.pdftron.com/. If you have already downloaded this
+        at https://dev.apryse.com/. If you have already downloaded this
         module, ensure that the SDK is able to find the required files
         using the PDFNet::AddResourceSearchPath() function.""")
 

--- a/Samples/OCRTest/RUBY/OCRTest.rb
+++ b/Samples/OCRTest/RUBY/OCRTest.rb
@@ -33,7 +33,7 @@ output_path = "../../TestFiles/Output/"
 			puts 'Unable to run OCRTest: PDFTron SDK OCR module not available.'
 			puts '---------------------------------------------------------------'
 			puts 'The OCR module is an optional add-on, available for download'
-			puts 'at http://www.pdftron.com/. If you have already downloaded this'
+			puts 'at https://dev.apryse.com/. If you have already downloaded this'
 			puts 'module, ensure that the SDK is able to find the required files'
 			puts 'using the PDFNet::AddResourceSearchPath() function.'
 

--- a/Samples/PDF2HtmlTest/GO/PDF2Html_test.go
+++ b/Samples/PDF2HtmlTest/GO/PDF2Html_test.go
@@ -29,7 +29,7 @@ func init() {
 // 2. The optional add-on module is used to convert PDF documents to HTML documents with
 //    text flowing across the browser window.
 //
-// The PDFTron SDK HTML add-on module can be downloaded from http://www.pdftron.com/
+// The PDFTron SDK HTML add-on module can be downloaded from https://dev.apryse.com/
 //
 // Please contact us if you have any questions.
 //---------------------------------------------------------------------------------------

--- a/Samples/PDF2HtmlTest/PHP/PDF2HtmlTest.php
+++ b/Samples/PDF2HtmlTest/PHP/PDF2HtmlTest.php
@@ -17,7 +17,7 @@ include("../../LicenseKey/PHP/LicenseKey.php");
 // 2. The optional add-on module is used to convert PDF documents to HTML documents with
 //    text flowing across the browser window.
 //
-// The PDFTron SDK HTML add-on module can be downloaded from http://www.pdftron.com/
+// The PDFTron SDK HTML add-on module can be downloaded from https://dev.apryse.com/
 //
 // Please contact us if you have any questions.
 //---------------------------------------------------------------------------------------

--- a/Samples/PDF2HtmlTest/PYTHON/PDF2HtmlTest.py
+++ b/Samples/PDF2HtmlTest/PYTHON/PDF2HtmlTest.py
@@ -23,7 +23,7 @@ from LicenseKey import *
 # 2. The optional add-on module is used to convert PDF documents to HTML documents with
 #    text flowing across the browser window.
 #
-# The PDFTron SDK HTML add-on module can be downloaded from http://www.pdftron.com/
+# The PDFTron SDK HTML add-on module can be downloaded from https://dev.apryse.com/
 #
 # Please contact us if you have any questions.
 #---------------------------------------------------------------------------------------

--- a/Samples/PDF2HtmlTest/RUBY/PDF2HtmlTest.rb
+++ b/Samples/PDF2HtmlTest/RUBY/PDF2HtmlTest.rb
@@ -19,7 +19,7 @@ $stdout.sync = true
 # 2. The optional add-on module is used to convert PDF documents to HTML documents with
 #    text flowing across the browser window.
 #
-# The PDFTron SDK HTML add-on module can be downloaded from http://www.pdftron.com/
+# The PDFTron SDK HTML add-on module can be downloaded from https://dev.apryse.com/
 #
 # Please contact us if you have any questions.
 #---------------------------------------------------------------------------------------

--- a/Samples/WebViewerConvertTest/GO/WebViewerConvert_test.go
+++ b/Samples/WebViewerConvertTest/GO/WebViewerConvert_test.go
@@ -39,7 +39,7 @@ func init() {
 //
 // Please note that PDFNet Publisher (i.e. 'pdftron.PDF.Convert.ToXod') is an
 // optionally licensable add-on to PDFNet Core SDK. For details, please see
-// http://www.pdftron.com/webviewer/licensing.html.
+// https://apryse.com/pricing.
 //---------------------------------------------------------------------------------------
 
 func TestWebViewerConvert(t *testing.T){

--- a/Samples/WebViewerConvertTest/PHP/WebViewerConvertTest.php
+++ b/Samples/WebViewerConvertTest/PHP/WebViewerConvertTest.php
@@ -26,7 +26,7 @@ include("../../LicenseKey/PHP/LicenseKey.php");
 //
 // Please note that PDFNet Publisher (i.e. 'pdftron.PDF.Convert.ToXod') is an
 // optionally licensable add-on to PDFNet Core SDK. For details, please see
-// http://www.pdftron.com/webviewer/licensing.html.
+// https://apryse.com/pricing.
 //---------------------------------------------------------------------------------------
 
 

--- a/Samples/WebViewerConvertTest/PYTHON/WebViewerConvertTest.py
+++ b/Samples/WebViewerConvertTest/PYTHON/WebViewerConvertTest.py
@@ -32,7 +32,7 @@ from LicenseKey import *
 #
 # Please note that PDFNet Publisher (i.e. 'pdftron.PDF.Convert.ToXod') is an
 # optionally licensable add-on to PDFNet Core SDK. For details, please see
-# http://www.pdftron.com/webviewer/licensing.html.
+# https://apryse.com/pricing.
 #---------------------------------------------------------------------------------------
 
 # Relative path to the folder containing the test files.

--- a/Samples/WebViewerConvertTest/RUBY/WebViewerConvertTest.rb
+++ b/Samples/WebViewerConvertTest/RUBY/WebViewerConvertTest.rb
@@ -29,7 +29,7 @@ $stdout.sync = true
 #
 # Please note that PDFNet Publisher (i.e. 'pdftron.PDF.Convert.ToXod') is an
 # optionally licensable add-on to PDFNet Core SDK. For details, please see
-# http://www.pdftron.com/webviewer/licensing.html.
+# https://apryse.com/pricing.
 #---------------------------------------------------------------------------------------
 
 # Relative path to the folder containing the test files.

--- a/Samples/WebViewerStreamingTest/PHP/ReadMe.txt
+++ b/Samples/WebViewerStreamingTest/PHP/ReadMe.txt
@@ -10,7 +10,7 @@ ConvertAndStream.php is a PHP web server script that will convert a source file 
 3. Copy the following files to their respective directories:
     a. Copy WebViewer.html to the root folder of htdocs (root folder where web serve will look for files).
     b. Copy PDFNetPHP.php (found in Lib folder of PDFNetC package) and ConvertAndStream.php to the root folder of htdocs.
-    c. Download the WebViewer Redistributable (WebViewer.zip) from here: http://www.pdftron.com/webviewer/download.html
+    c. Download the WebViewer Redistributable (WebViewer.zip) from here: https://dev.apryse.com/
     d. Extract the contents of WebViewer.zip to the root folder of htdocs (make sure you get the folder WebViewer/ inside htdocs root).
 
 4. Modify ConvertAndStream.php so the paths to the files are absolute. Enable logging by setting the $LOG_ENABLED variable to true if desired.

--- a/Samples/WebViewerStreamingTest/PYTHON/ReadMe.txt
+++ b/Samples/WebViewerStreamingTest/PYTHON/ReadMe.txt
@@ -5,7 +5,7 @@ ConvertAndStream.py is a Python Django script that will convert a source file to
 
 1. Download Django from http://www.djangoproject.com and install it.
 
-2. Download the WebViewer Redistributable (WebViewer.zip) from here: http://www.pdftron.com/webviewer/download.html
+2. Download the WebViewer Redistributable (WebViewer.zip) from here: https://dev.apryse.com/
 
 3. Extract the contents of WebViewer.zip to Samples/WebViewerStreaming/PYTHON (make sure you get the directory: Samples/WebViewerStreaming/PYTHON/WebViewer after extraction).
 


### PR DESCRIPTION
a lot of download links that uses www.pdftron.com still can't be replaced, for example:

on README.md
https://www.pdftron.com/downloads/PDFNetC64.tar.gz

can't be replaced with 

https://apryse.com/downloads/PDFNetC64.tar.gz
or
https://dev.apryse.com/downloads/PDFNetC64.tar.gz
