### PR TITLE
[Samples|OfficeToPDFTest] Sync up test files with PDFTronCore samples.

### DIFF
--- a/Samples/OfficeToPDFTest/GO/OfficeToPDF_test.go
+++ b/Samples/OfficeToPDFTest/GO/OfficeToPDF_test.go
@@ -105,10 +105,13 @@ func TestOfficeToPDF(t *testing.T){
     PDFNetSetResourcesPath("../../Resources")
 
     // first the one-line conversion function
-    SimpleDocxConvert("simple-word_2007.docx", "simple-word_2007.pdf")
+    SimpleDocxConvert("Fishermen.docx", "Fishermen.pdf")
 
     // then the more flexible line-by-line conversion API
     FlexibleDocxConvert("the_rime_of_the_ancient_mariner.docx", "the_rime_of_the_ancient_mariner.pdf")
+
+    // conversion of RTL content
+    FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf")
     PDFNetTerminate()
 
 }

--- a/Samples/OfficeToPDFTest/PHP/OfficeToPDFTest.php
+++ b/Samples/OfficeToPDFTest/PHP/OfficeToPDFTest.php
@@ -120,8 +120,8 @@ function main()
 	// then the more flexible line-by-line conversion API
 	FlexibleDocxConvert("the_rime_of_the_ancient_mariner.docx", "the_rime_of_the_ancient_mariner.pdf");
 
-    // conversion of RTL content
-    FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf");	
+	// conversion of RTL content
+	FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf");
 	PDFNet::Terminate();
 	echo(nl2br("Done.\n"));
 }

--- a/Samples/OfficeToPDFTest/PHP/OfficeToPDFTest.php
+++ b/Samples/OfficeToPDFTest/PHP/OfficeToPDFTest.php
@@ -115,10 +115,13 @@ function main()
 	PDFNet::SetResourcesPath("../../../Resources");
 
 	// first the one-line conversion function
-	SimpleDocxConvert("simple-word_2007.docx", "simple-word_2007.pdf");
+	SimpleDocxConvert("Fishermen.docx", "Fishermen.pdf");
 
 	// then the more flexible line-by-line conversion API
 	FlexibleDocxConvert("the_rime_of_the_ancient_mariner.docx", "the_rime_of_the_ancient_mariner.pdf");
+
+    // conversion of RTL content
+    FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf");	
 	PDFNet::Terminate();
 	echo(nl2br("Done.\n"));
 }

--- a/Samples/OfficeToPDFTest/PYTHON/OfficeToPDFTest.py
+++ b/Samples/OfficeToPDFTest/PYTHON/OfficeToPDFTest.py
@@ -91,10 +91,13 @@ def main():
     PDFNet.SetResourcesPath("../../../Resources")
 
     # first the one-line conversion function
-    SimpleDocxConvert("simple-word_2007.docx", "simple-word_2007.pdf")
+    SimpleDocxConvert("Fishermen.docx", "Fishermen.pdf")
 
     # then the more flexible line-by-line conversion API
     FlexibleDocxConvert("the_rime_of_the_ancient_mariner.docx", "the_rime_of_the_ancient_mariner.pdf")
+    
+    # conversion of RTL content
+    FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf")
     PDFNet.Terminate()
 
     print("Done.")

--- a/Samples/OfficeToPDFTest/RUBY/OfficeToPDFTest.rb
+++ b/Samples/OfficeToPDFTest/RUBY/OfficeToPDFTest.rb
@@ -99,10 +99,13 @@ def main()
     PDFNet.SetResourcesPath("../../../Resources")
 
     # first the one-line conversion function
-    SimpleDocxConvert("simple-word_2007.docx", "simple-word_2007.pdf")
+    SimpleDocxConvert("Fishermen.docx", "Fishermen.pdf")
 
     # then the more flexible line-by-line conversion API
     FlexibleDocxConvert("the_rime_of_the_ancient_mariner.docx", "the_rime_of_the_ancient_mariner.pdf")
+
+    # conversion of RTL content
+    FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf")
     PDFNet.Terminate
     puts "Done."
 end


### PR DESCRIPTION
- Modified `SimpleDocxConvert("simple-word_2007.docx", "simple-word_2007.pdf")` to `SimpleDocxConvert("Fishermen.docx", "Fishermen.pdf")`
- Added new one:
    // conversion of RTL content
    FlexibleDocxConvert("factsheet_Arabic.docx", "factsheet_Arabic.pdf")
