### PR TITLE
Naum/cap 747 swig overloads wrapper

### DIFF
--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1176,7 +1176,7 @@ namespace pdftron {
 	namespace Crypto {
 		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
 		{
-			return new ObjectIdentifier(const DigestAlgorithm::Type in_digest_algorithm);
+			return new ObjectIdentifier(in_digest_algorithm);
 		}
 
 		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,9 +42,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%ignore (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor
@@ -1169,3 +1169,25 @@ namespace pdftron {
 //#define Redaction Redaction
 %include "PDF/Redactor.h"
 //#undef Redaction
+
+// Create a instances by using ignored overloaded constructors
+%inline %{
+namespace pdftron {
+	namespace Crypto {
+		ObjectIdentifier* ObjectIdetnifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
+		{
+			return new ObjectIdetnifier::ObjectIdetnifier(const DigestAlgorithm::Type in_digest_algorithm);
+		}
+
+		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm)(const DigestAlgorithm::Type in_digest_algorithm)
+		{
+			return new AlgorithmIdentifier::AlgorithmIdentifier(in_digest_algorithm);
+		}
+		
+		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params)
+		{
+			return new pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(in_object_identifier, in_algo_params);
+		}
+	}
+}
+%}

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1170,11 +1170,11 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 //#undef Redaction
 
-// Create a static method for ambiguous overloaded constructor
+// Create a static methods for ambiguous overloaded constructors
+%extend pdftron::Crypto::ObjectIdentifier {
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-		static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-			return new ObjectIdentifier(in_digest_algorithm);
-		}
+        static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+            return new ObjectIdentifier(in_digest_algorithm);
+        }
 }
-%}

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -44,9 +44,9 @@
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
  * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1179,7 +1179,7 @@ namespace pdftron {
 			return new ObjectIdetnifier::ObjectIdetnifier(const DigestAlgorithm::Type in_digest_algorithm);
 		}
 
-		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm)(const DigestAlgorithm::Type in_digest_algorithm)
+		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
 		{
 			return new AlgorithmIdentifier::AlgorithmIdentifier(in_digest_algorithm);
 		}

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1173,7 +1173,7 @@ namespace pdftron {
 // Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-        static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+        static pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
             return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
         }
 }

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1172,7 +1172,6 @@ namespace pdftron {
 
 // Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
-%extend pdftron::Crypto::ObjectIdentifier {
         public:
         static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
             return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1174,18 +1174,15 @@ namespace pdftron {
 %inline %{
 namespace pdftron {
 	namespace Crypto {
-		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
-		{
+		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
 			return new ObjectIdentifier(in_digest_algorithm);
 		}
 
-		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
-		{
+		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
 			return new AlgorithmIdentifier(in_digest_algorithm);
 		}
 		
-		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params)
-		{
+		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params) {
 			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
 		}
 	}

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,9 +42,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (FromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (FromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (FromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1170,21 +1170,11 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 //#undef Redaction
 
-// Create a instances by using ignored overloaded constructors
-%inline %{
-namespace pdftron {
-	namespace Crypto {
-		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+// Create a static method for ambiguous overloaded constructor
+%extend pdftron::Crypto::ObjectIdentifier {
+        public:
+		static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
 			return new ObjectIdentifier(in_digest_algorithm);
 		}
-
-		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-			return new AlgorithmIdentifier(in_digest_algorithm);
-		}
-		
-		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params) {
-			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
-		}
-	}
 }
 %}

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1174,7 +1174,7 @@ namespace pdftron {
 %extend pdftron::Crypto::ObjectIdentifier {
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-        static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-            return new ObjectIdentifier(in_digest_algorithm);
+        static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+            return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
         }
 }

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1176,17 +1176,17 @@ namespace pdftron {
 	namespace Crypto {
 		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
 		{
-			return new ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type in_digest_algorithm);
+			return new ObjectIdentifier(const DigestAlgorithm::Type in_digest_algorithm);
 		}
 
 		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
 		{
-			return new AlgorithmIdentifier::AlgorithmIdentifier(in_digest_algorithm);
+			return new AlgorithmIdentifier(in_digest_algorithm);
 		}
 		
 		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params)
 		{
-			return new pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(in_object_identifier, in_algo_params);
+			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
 		}
 	}
 }

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -1174,9 +1174,9 @@ namespace pdftron {
 %inline %{
 namespace pdftron {
 	namespace Crypto {
-		ObjectIdentifier* ObjectIdetnifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
+		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)
 		{
-			return new ObjectIdetnifier::ObjectIdetnifier(const DigestAlgorithm::Type in_digest_algorithm);
+			return new ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type in_digest_algorithm);
 		}
 
 		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm)

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,9 +42,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%ignore (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%ignore (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%ignore (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,16 +42,11 @@
 /**
  * Fix ambiguous overloaded methods.
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
- * The second affected overloaded method in order (b) is marked as ignored and later renamed - to preserve functionality.
+ * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-//%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-//%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-
-//%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-//%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-
-//%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
-//%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,9 +42,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%rename (FromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (FromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (FromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,9 +42,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%rename (SetFromDigestAlgorithm)  pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (SetFromDigestAlgorithm)  pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (SetFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -40,13 +40,11 @@
 }
 
 /**
- * Fix ambiguous overloaded methods.
- * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
- * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
+ * Fix ambiguous overloaded methods
  */
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -42,9 +42,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (SetFromDigestAlgorithm)  pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (SetFromDigestAlgorithm)  pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (SetFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -43,12 +43,10 @@
 
 /**
  * Fix ambiguous overloaded methods.
- * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
- * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -1012,7 +1012,7 @@ namespace pdftron {
 // Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-        static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+        static pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
             return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
         }
 }

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -1012,7 +1012,7 @@ namespace pdftron {
 // Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-        static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-            return new ObjectIdentifier(in_digest_algorithm);
+        static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+            return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
         }
 }

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -44,9 +44,9 @@
 /**
  * Fix ambiguous overloaded methods.
  */
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -1009,21 +1009,11 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 //#undef Redaction
 
-// Create a instances by using ignored overloaded constructors
-%inline %{
-namespace pdftron {
-	namespace Crypto {
-		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+// Create a static method for ambiguous overloaded constructor
+%extend pdftron::Crypto::ObjectIdentifier {
+        public:
+		static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
 			return new ObjectIdentifier(in_digest_algorithm);
 		}
-
-		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-			return new AlgorithmIdentifier(in_digest_algorithm);
-		}
-		
-		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params) {
-			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
-		}
-	}
 }
 %}

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -46,9 +46,9 @@
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
  * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -44,16 +44,11 @@
 /**
  * Fix ambiguous overloaded methods.
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
- * The second affected overloaded method in order (b) is marked as ignored and later renamed - to preserve functionality.
+ * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
-%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -44,9 +44,9 @@
 /**
  * Fix ambiguous overloaded methods.
  */
-%rename(CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -44,9 +44,9 @@
 /**
  * Fix ambiguous overloaded methods.
  */
-%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename(CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -45,8 +45,8 @@
  * Fix ambiguous overloaded methods.
  */
 %rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -1009,11 +1009,10 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 //#undef Redaction
 
-// Create a static method for ambiguous overloaded constructor
+// Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-		static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-			return new ObjectIdentifier(in_digest_algorithm);
-		}
+        static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+            return new ObjectIdentifier(in_digest_algorithm);
+        }
 }
-%}

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -44,9 +44,9 @@
 /**
  * Fix ambiguous overloaded methods.
  */
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor
@@ -1009,3 +1009,21 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 //#undef Redaction
 
+// Create a instances by using ignored overloaded constructors
+%inline %{
+namespace pdftron {
+	namespace Crypto {
+		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+			return new ObjectIdentifier(in_digest_algorithm);
+		}
+
+		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+			return new AlgorithmIdentifier(in_digest_algorithm);
+		}
+		
+		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params) {
+			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
+		}
+	}
+}
+%}

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -287,6 +287,7 @@ namespace pdftron {
     namespace Crypto
     {
         class DigestAlgorithm;
+        class ObjectIdentifierFromDigestAlgorithm;
     }
     namespace PDF {
         class Font;

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -945,6 +945,6 @@ namespace pdftron {
                 : ObjectIdentifier(in_digest_algorithm_type)
             {
             }
-        }
+        };
     }
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -935,9 +935,9 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 
 // Extend from ObjectIdentifier to fix overloaded constructor
-%extend pdftron::Crypto::ObjectIdentifier {
+%extend pdftron::Crypto {
         public:
-		pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
+		pdftron::Crypto::ObjectIdentifier* ObjectIdentifierCreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
 			return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm_type);
 		}
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -35,15 +35,10 @@
 /**
  * Fix ambiguous overloaded methods.
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
- * The second affected overloaded method in order (b) is marked as ignored and later renamed - to preserve functionality.
+ * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-#%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
 %rename (FromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-
-#%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
 %rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-
-#%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 %rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -38,7 +38,7 @@
  * The second affected overloaded method in order (b) is marked as ignored and later renamed - to preserve functionality.
  */
 #%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (FromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
 
 #%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
 %rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -287,7 +287,6 @@ namespace pdftron {
     namespace Crypto
     {
         class DigestAlgorithm;
-        class ObjectIdentifierFromDigestAlgorithm;
     }
     namespace PDF {
         class Font;
@@ -935,17 +934,10 @@ namespace pdftron {
 %include "PDF/TextSearch.h"
 %include "PDF/Redactor.h"
 
-// Derive from ObjectIdentifier to fix overloaded constructor
-namespace pdftron {
-    namespace Crypto
-    {
-        class ObjectIdentifierFromDigestAlgorithm : public ObjectIdentifier
-        {
+// Extend from ObjectIdentifier to fix overloaded constructor
+%extend pdftron::Crypto::ObjectIdentifier {
         public:
-            ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm_type)
-                : ObjectIdentifier(in_digest_algorithm_type)
-            {
-            }
-        };
-    }
+		pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
+			return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm_type);
+		}
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -37,7 +37,7 @@
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
  * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
 %rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
 %rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
@@ -934,3 +934,17 @@ namespace pdftron {
 %include "PDF/TextSearch.h"
 %include "PDF/Redactor.h"
 
+// Derive from ObjectIdentifier to fix overloaded constructor
+namespace pdftron {
+    namespace Crypto
+    {
+        class ObjectIdentifierFromDigestAlgorithm : public ObjectIdentifier
+        {
+        public:
+            ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm_type)
+                : ObjectIdentifier(in_digest_algorithm_type)
+            {
+            }
+        }
+    }
+}

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -35,9 +35,9 @@
 /**
  * Fix ambiguous overloaded methods
  */
-%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (SetFromDigestAlgorithm)  pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (SetFromDigestAlgorithm)  pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (SetFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -934,9 +934,8 @@ namespace pdftron {
 
 // Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
-%extend pdftron::Crypto::ObjectIdentifier {
         public:
-        static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-            return new ObjectIdentifier(in_digest_algorithm);
+        static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+            return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
         }
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -932,11 +932,11 @@ namespace pdftron {
 %include "PDF/TextSearch.h"
 %include "PDF/Redactor.h"
 
-// Create a static method for ambiguous overloaded constructor
+// Create a static methods for ambiguous overloaded constructors
+%extend pdftron::Crypto::ObjectIdentifier {
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-		static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-			return new ObjectIdentifier(in_digest_algorithm);
-		}
+        static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+            return new ObjectIdentifier(in_digest_algorithm);
+        }
 }
-%}

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -37,9 +37,9 @@
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
  * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%rename (FromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (CreateFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -33,6 +33,20 @@
 }
 
 /**
+ * Fix ambiguous overloaded methods.
+ * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
+ * The second affected overloaded method in order (b) is marked as ignored and later renamed - to preserve functionality.
+ */
+#%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+
+#%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+
+#%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+
+/**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor
  * They are copied directly to the .c/.cxx file generated.
  */

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -37,9 +37,9 @@
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
  * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (CreateFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%rename (ObjectIdentifierFromDigestAlgorithm) pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -33,13 +33,6 @@
 }
 
 /**
- * Fix ambiguous overloaded methods
- */
-%rename (SetFromDigestAlgorithm)  pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
-%rename (SetFromDigestAlgorithm)  pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (SetFromObjectIdentifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
-
-/**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor
  * They are copied directly to the .c/.cxx file generated.
  */

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -935,9 +935,7 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 
 // Extend from ObjectIdentifier to fix overloaded constructor
-%extend pdftron::Crypto {
-        public:
+%extend {
 		pdftron::Crypto::ObjectIdentifier* ObjectIdentifierCreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
 			return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm_type);
-		}
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -932,21 +932,11 @@ namespace pdftron {
 %include "PDF/TextSearch.h"
 %include "PDF/Redactor.h"
 
-// Create a instances by using ignored overloaded constructors
-%inline %{
-namespace pdftron {
-	namespace Crypto {
-		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+// Create a static method for ambiguous overloaded constructor
+%extend pdftron::Crypto::ObjectIdentifier {
+        public:
+		static ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
 			return new ObjectIdentifier(in_digest_algorithm);
 		}
-
-		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
-			return new AlgorithmIdentifier(in_digest_algorithm);
-		}
-		
-		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params) {
-			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
-		}
-	}
 }
 %}

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -37,7 +37,6 @@
  * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
  * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
  */
-%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
 %rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
 %rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
@@ -934,10 +933,3 @@ namespace pdftron {
 %include "PDF/TextSearch.h"
 %include "PDF/Redactor.h"
 
-// Extend from ObjectIdentifier to fix overloaded constructor
-%extend pdftron::Crypto::ObjectIdentifier {
-		pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
-			pdftron::Crypto::ObjectIdentifier* poid = new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm_type);
-			return poid;
-		}
-}

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -33,6 +33,13 @@
 }
 
 /**
+ * Fix ambiguous overloaded methods
+ */
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+
+/**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor
  * They are copied directly to the .c/.cxx file generated.
  */
@@ -925,3 +932,21 @@ namespace pdftron {
 %include "PDF/TextSearch.h"
 %include "PDF/Redactor.h"
 
+// Create a instances by using ignored overloaded constructors
+%inline %{
+namespace pdftron {
+	namespace Crypto {
+		ObjectIdentifier* ObjectIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+			return new ObjectIdentifier(in_digest_algorithm);
+		}
+
+		AlgorithmIdentifier* AlgorithmIdentifierFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+			return new AlgorithmIdentifier(in_digest_algorithm);
+		}
+		
+		AlgorithmIdentifier* AlgorithmIdentifierFromObjectIdentifier(const ObjectIdentifier::Predefined in_object_identifier, const AlgorithmParams& in_algo_params) {
+			return new AlgorithmIdentifier(in_object_identifier, in_algo_params);
+		}
+	}
+}
+%}

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -935,7 +935,9 @@ namespace pdftron {
 %include "PDF/Redactor.h"
 
 // Extend from ObjectIdentifier to fix overloaded constructor
-%extend {
-		pdftron::Crypto::ObjectIdentifier* ObjectIdentifierCreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
-			return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm_type);
+%extend pdftron::Crypto::ObjectIdentifier {
+		pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const pdftron::Crypto::DigestAlgorithm::Type in_digest_algorithm_type) {
+			pdftron::Crypto::ObjectIdentifier* poid = new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm_type);
+			return poid;
+		}
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -935,7 +935,7 @@ namespace pdftron {
 // Create a static methods for ambiguous overloaded constructors
 %extend pdftron::Crypto::ObjectIdentifier {
         public:
-        static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
+        static pdftron::Crypto::ObjectIdentifier* CreateFromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
             return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
         }
 }

--- a/PDFNetRuby/PDFNetRuby.i
+++ b/PDFNetRuby/PDFNetRuby.i
@@ -33,12 +33,11 @@
 }
 
 /**
- * Fix ambiguous overloaded methods.
- * - Warning 509: Overloaded method 'b' effectively ignored as it is shadowed by 'a'
- * The second affected overloaded method in order (b) is renamed - to preserve intended functionality.
+ * Fix ambiguous overloaded methods
  */
-%rename (AlgorithmIdentifierFromDigestAlgorithm) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
-%rename (AlgorithmIdentifierFromObjectIdenifier) pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
+%ignore pdftron::Crypto::ObjectIdentifier::ObjectIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const DigestAlgorithm::Type);
+%ignore pdftron::Crypto::AlgorithmIdentifier::AlgorithmIdentifier(const ObjectIdentifier::Predefined, const AlgorithmParams&);
 
 /**
  * Text enclosed in the following %{...%} block is not processed by the SWIG preprocessor

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier::FromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::CreateFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,8 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = new ObjectIdentifier();
-	$digest_algorithm_oid.SetFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,8 +564,8 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid_temp ObjectIdentifier();
-	$digest_algorithm_oid = $digest_algorithm_oid_temp.ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid_temp = new ObjectIdentifier();
+	$digest_algorithm_oid = $digest_algorithm_oid_temp->ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::FromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier::ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = new ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,8 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = new ObjectIdentifier($digest_algorithm_type, true);
+	$digest_algorithm_oid = new ObjectIdentifier();
+	$digest_algorithm_oid.SetFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,8 +564,8 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid_temp = new ObjectIdentifier();
-	$digest_algorithm_oid = $digest_algorithm_oid_temp->ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid_temp ObjectIdentifier();
+	$digest_algorithm_oid = $digest_algorithm_oid_temp.ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,8 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = new ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = new ObjectIdentifier();
+	$digest_algorithm_oid.ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier::FromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,8 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid_temp = new ObjectIdentifier();
-	$digest_algorithm_oid = $digest_algorithm_oid_temp->ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier::FromADigestlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::CreateFromDigestlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,8 +564,8 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = new ObjectIdentifier();
-	$digest_algorithm_oid->ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid_temp = new ObjectIdentifier();
+	$digest_algorithm_oid = $digest_algorithm_oid_temp->ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier::CreateFromDigestlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = new ObjectIdentifier($digest_algorithm_type, true);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier::CreateFromADigestlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifierFromADigestlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -565,7 +565,7 @@ function CustomSigningAPI($doc_path,
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
 	$digest_algorithm_oid = new ObjectIdentifier();
-	$digest_algorithm_oid.ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid->ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifierFromADigestlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::FromADigestlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = new ObjectIdentifier($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::CreateFromADigestlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
+++ b/Samples/DigitalSignaturesTest/PHP/DigitalSignaturesTest.php
@@ -564,7 +564,7 @@ function CustomSigningAPI($doc_path,
 
 	// Then, create ObjectIdentifiers for the algorithms you have used.
 	// Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	$digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm($digest_algorithm_type);
+	$digest_algorithm_oid = ObjectIdentifier::FromDigestAlgorithm($digest_algorithm_type);
 	$signature_algorithm_oid = new ObjectIdentifier(ObjectIdentifier::e_RSA_encryption_PKCS1);
 
 	// Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -503,17 +503,17 @@ def CustomSigningAPI(doc_path,
 	elif version == 3:
 		print("-- Version 3")
 		params = AlgorithmParams()
-
+		print("-- 506")
 		# C++:
 		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type, params);
 		digest_algorithm_oid = AlgorithmIdentifier(digest_algorithm_type, params)
-
+		print("-- 510")
 		# C++:
 		# Crypto::AlgorithmIdentifier signature_algorithm (Crypto::ObjectIdentifier::e_RSA_encryption_PKCS1, params);
 		signature_algorithm_oid = AlgorithmIdentifierFromObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1, params)
-
+		print("-- 514")
 		options = CMSSignatureOptions()
-
+		print("-- 516")
 		# Then, put the CMS signature components together.
 
 		# C++:
@@ -523,10 +523,10 @@ def CustomSigningAPI(doc_path,
 		cms_signature = DigitalSignatureField.GenerateCMSSignature(
 			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
 			signature_value, signedAttrs, options)
-
+		print("-- 526")
 	# Write the signature to the document.
 	doc.SaveCustomSignature(cms_signature, digsig_field, output_path)
-
+	print("-- 529")
 	print('================================================================================')
 
 def TimestampAndEnableLTV(in_docpath, 

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,8 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier()
-	digest_algorithm_oid.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -465,68 +465,19 @@ def CustomSigningAPI(doc_path,
 	# Then, load all your chain certificates into a container of X509Certificate.
 	chain_certs = []
 
-	version = 3           # 1, 2, 3
-	if version == 1:
-		print("-- Version 1")
-		# Then, create ObjectIdentifiers for the algorithms you have used.
-		# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-		digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type)
-		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
+	# Then, create ObjectIdentifiers for the algorithms you have used.
+	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type)
+	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
-		# Then, put the CMS signature components together.
-		cms_signature = DigitalSignatureField.GenerateCMSSignature(
-			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-			signature_value, signedAttrs)
+	# Then, put the CMS signature components together.
+	cms_signature = DigitalSignatureField.GenerateCMSSignature(
+		signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+		signature_value, signedAttrs)
 
-	elif version == 2:
-		print("-- Version 2")
-		# Then, create ObjectIdentifiers for the algorithms you have used.
-		# Here we use digest_algorithm_type (usually SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-
-		# C++:
-		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type);
-		digest_algorithm_oid = AlgorithmIdentifierFromDigestAlgorithm(digest_algorithm_type)
-
-		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
-		options = CMSSignatureOptions()
-
-		# Then, put the CMS signature components together.
-
-		# C++:
-		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
-		# 	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
-		# 	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
-		cms_signature = DigitalSignatureField.GenerateCMSSignature(
-			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-			signature_value, signedAttrs, options)
-
-	elif version == 3:
-		print("-- Version 3")
-		params = AlgorithmParams()
-		print("-- 506")
-		# C++:
-		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type, params);
-		digest_algorithm_oid = AlgorithmIdentifier(digest_algorithm_type, params)
-		print("-- 510")
-		# C++:
-		# Crypto::AlgorithmIdentifier signature_algorithm (Crypto::ObjectIdentifier::e_RSA_encryption_PKCS1, params);
-		signature_algorithm_oid = AlgorithmIdentifierFromObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1, params)
-		print("-- 514")
-		options = CMSSignatureOptions()
-		print("-- 516")
-		# Then, put the CMS signature components together.
-
-		# C++:
-		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
-		#	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
-		#	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
-		cms_signature = DigitalSignatureField.GenerateCMSSignature(
-			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-			signature_value, signedAttrs, options)
-		print("-- 526")
 	# Write the signature to the document.
 	doc.SaveCustomSignature(cms_signature, digsig_field, output_path)
-	print("-- 529")
+
 	print('================================================================================')
 
 def TimestampAndEnableLTV(in_docpath, 

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifier(digest_algorithm_type, True)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_SHA256)
+	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -465,19 +465,68 @@ def CustomSigningAPI(doc_path,
 	# Then, load all your chain certificates into a container of X509Certificate.
 	chain_certs = []
 
-	# Then, create ObjectIdentifiers for the algorithms you have used.
-	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type)
-	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
+	version = 3           # 1, 2, 3
+	if version == 1:
+		print("-- Version 1")
+		# Then, create ObjectIdentifiers for the algorithms you have used.
+		# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+		digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
+		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
-	# Then, put the CMS signature components together.
-	cms_signature = DigitalSignatureField.GenerateCMSSignature(
-		signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-		signature_value, signedAttrs)
+		# Then, put the CMS signature components together.
+		cms_signature = DigitalSignatureField.GenerateCMSSignature(
+			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+			signature_value, signedAttrs)
 
+	elif version == 2:
+		print("-- Version 2")
+		# Then, create ObjectIdentifiers for the algorithms you have used.
+		# Here we use digest_algorithm_type (usually SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+
+		# C++:
+		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type);
+		digest_algorithm_oid = AlgorithmIdentifierFromDigestAlgorithm(digest_algorithm_type)
+
+		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
+		options = CMSSignatureOptions()
+
+		# Then, put the CMS signature components together.
+
+		# C++:
+		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
+		# 	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
+		# 	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
+		cms_signature = DigitalSignatureField.GenerateCMSSignature(
+			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+			signature_value, signedAttrs, options)
+
+	elif version == 3:
+		print("-- Version 3")
+		params = AlgorithmParams()
+		print("-- 506")
+		# C++:
+		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type, params);
+		digest_algorithm_oid = AlgorithmIdentifier(digest_algorithm_type, params)
+		print("-- 510")
+		# C++:
+		# Crypto::AlgorithmIdentifier signature_algorithm (Crypto::ObjectIdentifier::e_RSA_encryption_PKCS1, params);
+		signature_algorithm_oid = AlgorithmIdentifierFromObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1, params)
+		print("-- 514")
+		options = CMSSignatureOptions()
+		print("-- 516")
+		# Then, put the CMS signature components together.
+
+		# C++:
+		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
+		#	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
+		#	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
+		cms_signature = DigitalSignatureField.GenerateCMSSignature(
+			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+			signature_value, signedAttrs, options)
+		print("-- 526")
 	# Write the signature to the document.
 	doc.SaveCustomSignature(cms_signature, digsig_field, output_path)
-
+	print("-- 529")
 	print('================================================================================')
 
 def TimestampAndEnableLTV(in_docpath, 

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -465,15 +465,64 @@ def CustomSigningAPI(doc_path,
 	# Then, load all your chain certificates into a container of X509Certificate.
 	chain_certs = []
 
-	# Then, create ObjectIdentifiers for the algorithms you have used.
-	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
-	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
+	version = 2           # 1, 2, 3
+	if version == 1:
+		print("-- Version 1")
+		# Then, create ObjectIdentifiers for the algorithms you have used.
+		# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+		digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
+		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
-	# Then, put the CMS signature components together.
-	cms_signature = DigitalSignatureField.GenerateCMSSignature(
-		signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-		signature_value, signedAttrs)
+		# Then, put the CMS signature components together.
+		cms_signature = DigitalSignatureField.GenerateCMSSignature(
+			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+			signature_value, signedAttrs)
+
+	elif version == 2:
+		print("-- Version 2")
+		# Then, create ObjectIdentifiers for the algorithms you have used.
+		# Here we use digest_algorithm_type (usually SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+
+		# C++:
+		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type);
+		digest_algorithm_oid = AlgorithmIdentifierFromDigestAlgorithm(digest_algorithm_type)
+
+		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
+		options = CMSSignatureOptions()
+
+		# Then, put the CMS signature components together.
+
+		# C++:
+		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
+		# 	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
+		# 	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
+		cms_signature = DigitalSignatureField.GenerateCMSSignature(
+			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+			signature_value, signedAttrs, options)
+
+	elif version == 3:
+		print("-- Version 3")
+		params = AlgorithmParams()
+
+		# C++:
+		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type, params);
+		digest_algorithm_oid = AlgorithmIdentifier(digest_algorithm_type, params)
+
+		# C++:
+		# Crypto::AlgorithmIdentifier signature_algorithm (Crypto::ObjectIdentifier::e_RSA_encryption_PKCS1, params);
+		signature_algorithm_oid = AlgorithmIdentifierFromObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1, params)
+
+		options = CMSSignatureOptions()
+
+		# Then, put the CMS signature components together.
+
+		# C++:
+		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
+		#	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
+		#	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
+		cms_signature = DigitalSignatureField.GenerateCMSSignature(
+			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+			signature_value, signedAttrs, options)
 
 	# Write the signature to the document.
 	doc.SaveCustomSignature(cms_signature, digsig_field, output_path)

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -465,7 +465,7 @@ def CustomSigningAPI(doc_path,
 	# Then, load all your chain certificates into a container of X509Certificate.
 	chain_certs = []
 
-	version = 2           # 1, 2, 3
+	version = 3           # 1, 2, 3
 	if version == 1:
 		print("-- Version 1")
 		# Then, create ObjectIdentifiers for the algorithms you have used.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -470,7 +470,7 @@ def CustomSigningAPI(doc_path,
 		print("-- Version 1")
 		# Then, create ObjectIdentifiers for the algorithms you have used.
 		# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-		digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
+		digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type)
 		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 		# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -465,68 +465,19 @@ def CustomSigningAPI(doc_path,
 	# Then, load all your chain certificates into a container of X509Certificate.
 	chain_certs = []
 
-	version = 3           # 1, 2, 3
-	if version == 1:
-		print("-- Version 1")
-		# Then, create ObjectIdentifiers for the algorithms you have used.
-		# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-		digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
-		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
+	# Then, create ObjectIdentifiers for the algorithms you have used.
+	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
+	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
-		# Then, put the CMS signature components together.
-		cms_signature = DigitalSignatureField.GenerateCMSSignature(
-			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-			signature_value, signedAttrs)
+	# Then, put the CMS signature components together.
+	cms_signature = DigitalSignatureField.GenerateCMSSignature(
+		signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
+		signature_value, signedAttrs)
 
-	elif version == 2:
-		print("-- Version 2")
-		# Then, create ObjectIdentifiers for the algorithms you have used.
-		# Here we use digest_algorithm_type (usually SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-
-		# C++:
-		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type);
-		digest_algorithm_oid = AlgorithmIdentifierFromDigestAlgorithm(digest_algorithm_type)
-
-		signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
-		options = CMSSignatureOptions()
-
-		# Then, put the CMS signature components together.
-
-		# C++:
-		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
-		# 	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
-		# 	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
-		cms_signature = DigitalSignatureField.GenerateCMSSignature(
-			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-			signature_value, signedAttrs, options)
-
-	elif version == 3:
-		print("-- Version 3")
-		params = AlgorithmParams()
-		print("-- 506")
-		# C++:
-		# Crypto::AlgorithmIdentifier digest_algorithm(digest_algorithm_type, params);
-		digest_algorithm_oid = AlgorithmIdentifier(digest_algorithm_type, params)
-		print("-- 510")
-		# C++:
-		# Crypto::AlgorithmIdentifier signature_algorithm (Crypto::ObjectIdentifier::e_RSA_encryption_PKCS1, params);
-		signature_algorithm_oid = AlgorithmIdentifierFromObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1, params)
-		print("-- 514")
-		options = CMSSignatureOptions()
-		print("-- 516")
-		# Then, put the CMS signature components together.
-
-		# C++:
-		# std::vector<UChar> cms_signature = DigitalSignatureField::GenerateCMSSignature(
-		#	signer_cert, chain_certs.data(), chain_certs.size(), digest_algorithm, signature_algorithm,
-		#	signature_value.data(), signature_value.size(), signedAttrs.data(), signedAttrs.size(), options);
-		cms_signature = DigitalSignatureField.GenerateCMSSignature(
-			signer_cert, chain_certs, digest_algorithm_oid, signature_algorithm_oid,
-			signature_value, signedAttrs, options)
-		print("-- 526")
 	# Write the signature to the document.
 	doc.SaveCustomSignature(cms_signature, digsig_field, output_path)
-	print("-- 529")
+
 	print('================================================================================')
 
 def TimestampAndEnableLTV(in_docpath, 

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,8 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier(digest_algorithm_type, True)
+	digest_algorithm_oid = ObjectIdentifier()
+	digest_algorithm_oid.SetFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -467,7 +467,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
+++ b/Samples/DigitalSignaturesTest/PYTHON/DigitalSignaturesTest.py
@@ -468,7 +468,7 @@ def CustomSigningAPI(doc_path,
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
 	digest_algorithm_oid = ObjectIdentifier()
-	digest_algorithm_oid.SetFromDigestAlgorithm(digest_algorithm_type)
+	digest_algorithm_oid.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type)
 	signature_algorithm_oid = ObjectIdentifier(ObjectIdentifier.e_RSA_encryption_PKCS1)
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -446,9 +446,9 @@ def CustomSigningAPI(doc_path,
 		output_path)
 	puts('================================================================================');
 	puts('Custom signing PDF document');
-
+	puts digest_algorithm_type.class;
 	doc = PDFDoc.new(doc_path);
-
+	puts "digest_algorithm_type value: #{digest_algorithm_type}";
 	page1 = doc.GetPage(1);
 
 	digsig_field = doc.CreateDigitalSignatureField(cert_field_name);
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.new(DigestAlgorithm::E_SHA256);
+	digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.
@@ -675,6 +675,9 @@ def main()
 	# with access to Hardware Security Module (HSM) tokens/devices, access to cloud keystores, access
 	# to system keystores, etc.
 	begin
+		DigestAlgorithm.each_with_object("xyz") do |item, obj|;
+			puts "#{obj}: #{item}"
+		end
 		CustomSigningAPI(input_path + "waiver.pdf",
 			"PDFTronApprovalSig",
 			input_path + "pdftron.pfx",

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,10 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	a = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
-	a.methods.length;
-	a.methods;
-	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifierCreateFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,10 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifierCreateFromDigestAlgorithm(digest_algorithm_type);
+	a = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
+	a.methods.length;
+	a.methods;
+	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -506,7 +506,7 @@ def CustomSigningAPI(doc_path,
 	a = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 	a.methods.length;
 	a.methods;
-	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm.new(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier::CreateFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.new(digest_algorithm_type, true);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,8 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.new();
-	digest_algorithm_oid.SetFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_SHA256);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_SHA256);
+	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	a = ObjectIdentifier.new;
+	a = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 	a.methods.length;
 	a.methods;
 	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm.new(digest_algorithm_type);

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -506,7 +506,7 @@ def CustomSigningAPI(doc_path,
 	a = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 	a.methods.length;
 	a.methods;
-	digest_algorithm_oid = ObjectIdentifier::CreateFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,8 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.new(digest_algorithm_type, true);
+	digest_algorithm_oid = ObjectIdentifier.new();
+	digest_algorithm_oid.SetFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -446,9 +446,9 @@ def CustomSigningAPI(doc_path,
 		output_path)
 	puts('================================================================================');
 	puts('Custom signing PDF document');
-	puts digest_algorithm_type.class;
+
 	doc = PDFDoc.new(doc_path);
-	puts "digest_algorithm_type value: #{digest_algorithm_type}";
+
 	page1 = doc.GetPage(1);
 
 	digsig_field = doc.CreateDigitalSignatureField(cert_field_name);
@@ -675,9 +675,6 @@ def main()
 	# with access to Hardware Security Module (HSM) tokens/devices, access to cloud keystores, access
 	# to system keystores, etc.
 	begin
-		DigestAlgorithm.each_with_object("xyz") do |item, obj|;
-			puts "#{obj}: #{item}"
-		end
 		CustomSigningAPI(input_path + "waiver.pdf",
 			"PDFTronApprovalSig",
 			input_path + "pdftron.pfx",

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm.new(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.FromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,6 +503,9 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
+	a = ObjectIdentifier.new;
+	a.methods.length;
+	a.methods;
 	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm.new(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,7 +503,7 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	digest_algorithm_oid = ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
+	digest_algorithm_oid = ObjectIdentifier.ObjectIdentifierFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 
 	# Then, put the CMS signature components together.

--- a/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
+++ b/Samples/DigitalSignaturesTest/RUBY/DigitalSignaturesTest.rb
@@ -503,9 +503,6 @@ def CustomSigningAPI(doc_path,
 
 	# Then, create ObjectIdentifiers for the algorithms you have used.
 	# Here we use digest_algorithm_type (SHA256) for hashing, and RSAES-PKCS1-v1_5 (specified in the private key) for signing.
-	a = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
-	a.methods.length;
-	a.methods;
 	digest_algorithm_oid = ObjectIdentifier.CreateFromDigestAlgorithm(digest_algorithm_type);
 	signature_algorithm_oid = ObjectIdentifier.new(ObjectIdentifier::E_RSA_encryption_PKCS1);
 


### PR DESCRIPTION
### Description
SWIG has issues with C++ overloaded methods (and constructors) to target scripting languages like Python, PHP and Ruby, like:
```
class ObjectIdentifier
{
public:
    ObjectIdentifier(const Predefined in_oid_enum);
    ObjectIdentifier(const DigestAlgorithm::Type in_digest_algorithm_type);
    // etc.
};
```
Both constructors take integral as input and, when called from scripting language (Python, PHP, Ruby), which knows just for one Integer type, SWIG has no way to unambiguosly distinguish which constructor to call. Therefor, SWIG offers several options to overcome that:
1.	`%rename` the second overloaded method and call it from the script by new name, say `FromDigestAlgorithm()`.
	It is fine for class method but not for constructor since one need an instance to call it and SWIG doesn't add a `static` prefix to call it as `static`. One need to create a dummy instance to call the instance method:
	```
	ObjectIdentifier dummy();
	ObjectIdentifier oid = dummy.FromDigestAlgorithm(in_digest_algorithm_type);
	```
	This way to go is rejected.

2.	`%inline` the second method by creating a global (non-class-related) `static` method to do the above (1.) job. In script it would be called like:
	```
	ObjectIdentifier oid1 = ObjectIdentifierFromDigestAlgorithm(in_digest_algorithm_type);	// construct from `DigestAlgorithm::Type`
	```
	This works, but may confuse the developer. Say, in a similar case one should create instance as:
	```
	ObjectIdentifier oid1 = ObjectIdentifier(in_oid_enum);	// construct from Crypto::Predefined
	```
	Developer doesn't need to know that it is a SWIG that dictates the API which may look confusing.

3.	`%extend` the `ObjectIdentifier` class (internally and locally to SWIG) with a static method that will call propper constructor:
	```
	%extend pdftron::Crypto::ObjectIdentifier {
		public:
		static pdftron::Crypto::ObjectIdentifier* FromDigestAlgorithm(const DigestAlgorithm::Type in_digest_algorithm) {
			return new pdftron::Crypto::ObjectIdentifier(in_digest_algorithm);
		}
	}
	```
	The developer could call:
	```
		ObjectIdentifier oid1 = ObjectIdentifier(in_oid_enum);	// construct from Crypto::Predefined
		ObjectIdentifier oid2 = ObjectIdentifier.FromDigestAlgorithm(in_digest_algorithm_type);	// construct from `DigestAlgorithm::Type`
	```
	This is acceptable solutuion. But there is one additional proposal...

4.	Could we have a static method for the first case too and let it look like:
	```
	ObjectIdentifier oid1 = ObjectIdentifier.FromPredefined(in_oid_enum);	// construct from Crypto::Predefined
	ObjectIdentifier oid2 = ObjectIdentifier.FromDigestAlgorithm(in_digest_algorithm_type);	// construct from `DigestAlgorithm::Type`
	```

	Or, generally, could we wrap all overloaded constructors (and methods) with this kind of extension?
	
	Q: What to do with customers that already use current API?
	A: They can continue as is is now, but with one note in the documentation: "Deprecated. Please use new notation ..."

5.	During `Script/GenSwigWrappers.py` run, there are several important products that are left in dark and that may be good to be uploaded somehow:

    `PDFNetPython/PDFNetPython.cpp`
    `PDFNetPython/PDFNetPython.hpp`
    `PDFNetPython/PDFNetPython.py`

    `PDFNetPHP/PDFNetPHP.cpp`
    `PDFNetPHP/PDFNetPHP.php`
    `PDFNetPHP/php_PDFNetPHP.h`

    `PDFNetRuby/PDFNetRuby.cpp`
    `PDFNetRuby/PDFNetRuby.hpp`

    `PDFNet*/swig.log`
    `PDFNet*/swig.err.log`

    SWIG log files hides lot of overloading and missing defs info which would be good to look if some doesn;t work.

### Changelog entry
N/A

### Jenkins Builds
**Wrappers ...**
**... Python3 Windows** [https://jenkins.apryse.com/job/Wrappers Python3 Windows/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Python3%20Windows/job/naum%252Fcap-747-SWIG-overloads-wrapper/13/)
**... Windows32**	[https://jenkins.apryse.com/job/Wrappers Windows32/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Windows32/job/naum%252Fcap-747-SWIG-overloads-wrapper/6/)

**... Python3 Linux**	[https://jenkins.apryse.com/job/Wrappers Python3 Linux/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Python3%20Linux/job/naum%252Fcap-747-SWIG-overloads-wrapper/10/)
**... Python3 Linux32**	[https://jenkins.apryse.com/job/Wrappers Python3 Linux32/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Python3%20Linux32/job/naum%252Fcap-747-SWIG-overloads-wrapper/8/)

**... Python Arm64**	[https://jenkins.apryse.com/job/Wrappers Python3 Linux ARM64/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Python3%20Linux%20ARM64/job/naum%252Fcap-747-SWIG-overloads-wrapper/7/)

**... Python Alpine**	[https://jenkins.apryse.com/job/Wrappers Python Alpine/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Python%20Alpine/job/naum%252Fcap-747-SWIG-overloads-wrapper/7/)

**... Mac**			[https://jenkins.apryse.com/job/Wrappers Mac/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Mac/job/naum%252Fcap-747-SWIG-overloads-wrapper/9/)

**... PHP Linux**		[https://jenkins.apryse.com/job/Wrappers PHP Linux/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20PHP%20Linux/job/naum%252Fcap-747-SWIG-overloads-wrapper/28/)
**... PHP Alpine**		[https://jenkins.apryse.com/job/Wrappers PHP Alpine/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20PHP%20Alpine/job/naum%252Fcap-747-SWIG-overloads-wrapper/17)

**... Ruby Alpine**		[https://jenkins.apryse.com/job/Wrappers%20Ruby%20Alpine/job/naum%252Fcap-747-SWIG-overloads-wrapper/](https://jenkins.apryse.com/job/Wrappers%20Ruby%20Alpine/job/naum%252Fcap-747-SWIG-overloads-wrapper/60/)

More details in:
- https://apryse.atlassian.net/browse/CAP-1236/
- https://apryse.atlassian.net/browse/CAP-747/
