### PR TITLE
TSW-1950: removal of 'sudo' from sample scripts

### DIFF
--- a/Samples/BarcodeTest/RUBY/RunTest.sh
+++ b/Samples/BarcodeTest/RUBY/RunTest.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 TEST_NAME=BarcodeTest
 export LD_LIBRARY_PATH=../../../PDFNetC/Lib
-sudo ruby $TEST_NAME.rb
+ruby $TEST_NAME.rb

--- a/Samples/CAD2PDFTest/RUBY/RunTest.sh
+++ b/Samples/CAD2PDFTest/RUBY/RunTest.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 TEST_NAME=CAD2PDFTest
 export LD_LIBRARY_PATH=../../../PDFNetC/Lib
-sudo ruby $TEST_NAME.rb
+ruby $TEST_NAME.rb

--- a/Samples/HandwritingICRTest/RUBY/RunTest.sh
+++ b/Samples/HandwritingICRTest/RUBY/RunTest.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 TEST_NAME=HandwritingICRTest
 export LD_LIBRARY_PATH=../../../PDFNetC/Lib
-sudo ruby $TEST_NAME.rb
+ruby $TEST_NAME.rb

--- a/Samples/OCRTest/RUBY/RunTest.sh
+++ b/Samples/OCRTest/RUBY/RunTest.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 TEST_NAME=OCRTest
 export LD_LIBRARY_PATH=../../../PDFNetC/Lib
-sudo ruby $TEST_NAME.rb
+ruby $TEST_NAME.rb


### PR DESCRIPTION
### Summary

Some scripts use the 'sudo' command, which requires the root password to run tests. This made running tests impossible for many users.

And even if the root password is known, a read-only PDF file is created with root privileges, which leads to difficulties with subsequent running of samples for other language bindings. (As they do not require 'sudo')

### Context/Why?

n/a

### Implementation notes

sudo removed

### How to verify

Re-run the Ruby samples, followed by PHP samples. No root password prompt expected; PHP samples finished successfully

### Changelog entry

n/a
