### PR TITLE
Fix for syntax error running HighlightsTest.py with Python version less than 3.6

### DIFF
--- a/Samples/HighlightsTest/PYTHON/HighlightsTest.py
+++ b/Samples/HighlightsTest/PYTHON/HighlightsTest.py
@@ -86,7 +86,7 @@ def main():
             highlight.RefreshAppearance()
             page.AnnotPushBack(highlight)
 
-            print(f"[{x1:.2f}, {y1:.2f}, {x2:.2f}, {y2:.2f}]")
+            print("[{:.2f}, {:.2f}, {:.2f}, {:.2f}]".format(x1, y1, x2, y2))
 
         hlts.Next()
 


### PR DESCRIPTION
Clean copy of [this](https://github.com/ApryseSDK/PDFNetWrappers/pull/220) PR from @rogerk-apryse.

### Summary

Fix for syntax error running HightlightsTest.py with Python version < 3.6

### Context/Why?

N/A

### Implementation notes

N/A

### How to verify

N/A

### Changelog entry

N/A
