### PR TITLE
[WDS-3073] Fixed cron trigger for go builds

### DIFF
--- a/jenkinsfiles/build_alpine_go.groovy
+++ b/jenkinsfiles/build_alpine_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "pre_release" || env.BRANCH_NAME == "master" || env.BRANCH_NAME == "next_release") && getWrappersBranch(env.BRANCH_NAME) != "disabled" ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent {
@@ -19,10 +19,11 @@ pipeline {
         skipDefaultCheckout()
     }
 
+    triggers { cron(cron_string) }
+
     environment {
         GOCACHE      = "/tmp/.cache"
     }
-
 
     parameters {
         string(name: "FORCE_BRANCH_VERSION", defaultValue: "" ,

--- a/jenkinsfiles/build_alpine_go.groovy
+++ b/jenkinsfiles/build_alpine_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getJenkinsVersion(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent {

--- a/jenkinsfiles/build_linux_arm_go.groovy
+++ b/jenkinsfiles/build_linux_arm_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getJenkinsVersion(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent {

--- a/jenkinsfiles/build_linux_arm_go.groovy
+++ b/jenkinsfiles/build_linux_arm_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "pre_release" || env.BRANCH_NAME == "master" || env.BRANCH_NAME == "next_release") && getWrappersBranch(env.BRANCH_NAME) != "disabled" ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent {
@@ -19,13 +19,11 @@ pipeline {
         skipDefaultCheckout()
     }
 
-
     triggers { cron(cron_string) }
 
     environment {
         GOCACHE      = "/tmp/.cache"
     }
-
 
     parameters {
         string(name: "FORCE_BRANCH_VERSION", defaultValue: "" ,

--- a/jenkinsfiles/build_linux_go.groovy
+++ b/jenkinsfiles/build_linux_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getJenkinsVersion(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent {

--- a/jenkinsfiles/build_linux_go.groovy
+++ b/jenkinsfiles/build_linux_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "pre_release" || env.BRANCH_NAME == "master" || env.BRANCH_NAME == "next_release") && getWrappersBranch(env.BRANCH_NAME) != "disabled" ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent {
@@ -19,13 +19,11 @@ pipeline {
         skipDefaultCheckout()
     }
 
-
     triggers { cron(cron_string) }
 
     environment {
         GOCACHE      = "/tmp/.cache"
     }
-
 
     parameters {
         string(name: "FORCE_BRANCH_VERSION", defaultValue: "" ,

--- a/jenkinsfiles/build_mac_arm_go.groovy
+++ b/jenkinsfiles/build_mac_arm_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "pre_release" || env.BRANCH_NAME == "master" || env.BRANCH_NAME == "next_release") && getWrappersBranch(env.BRANCH_NAME) != "disabled" ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent { label 'Silitron' }

--- a/jenkinsfiles/build_mac_arm_go.groovy
+++ b/jenkinsfiles/build_mac_arm_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getJenkinsVersion(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent { label 'Silitron' }

--- a/jenkinsfiles/build_mac_go.groovy
+++ b/jenkinsfiles/build_mac_go.groovy
@@ -1,6 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "pre_release" || env.BRANCH_NAME == "master" || env.BRANCH_NAME == "next_release") && getWrappersBranch(env.BRANCH_NAME) != "disabled" ? cron_default : ""
-
+String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent { label 'Courage' }
@@ -9,6 +8,7 @@ pipeline {
         quietPeriod(60)
         disableConcurrentBuilds()
         timeout(time: 2, unit: 'HOURS')
+        skipDefaultCheckout()
     }
 
     environment {

--- a/jenkinsfiles/build_mac_go.groovy
+++ b/jenkinsfiles/build_mac_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getJenkinsVersion(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent { label 'Courage' }

--- a/jenkinsfiles/build_win_go.groovy
+++ b/jenkinsfiles/build_win_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "pre_release" || env.BRANCH_NAME == "master" || env.BRANCH_NAME == "next_release") && getWrappersBranch(env.BRANCH_NAME) != "disabled" ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent { label 'windows_fleet' }

--- a/jenkinsfiles/build_win_go.groovy
+++ b/jenkinsfiles/build_win_go.groovy
@@ -1,5 +1,5 @@
 String cron_default = "0 0 * * *"
-String cron_string = (env.BRANCH_NAME == "master" || getWrappersBranch(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
+String cron_string = (env.BRANCH_NAME == "master" || getJenkinsVersion(env.BRANCH_NAME) == "pre-release") ? cron_default : ""
 
 pipeline {
     agent { label 'windows_fleet' }


### PR DESCRIPTION
### Summary

This PR updates the cron triggers on our go builds to trigger the build daily for master or release branches prior to release. Also, it cleans up the go build pipelines, as some randomly had the cron trigger or skipDefaultCheckou missing, or random newlines.

### Context/Why?

The cron triggers on our go builds have been broken since we discontinued the use of wrappers_version.txt, which happened when we changed how PDFNetWrappers branches during release time. getWrappersBranch still existed, but it used the no longer updated or accurate wrappers_version.txt still on S3. 

### Implementation notes

Rather than just trigger master daily, now the cron trigger checks to see whether the branch is master OR its a pre-release branch, according to jenkins_version.txt.

### How to verify

master should build automatically, as it has been, after this change. After next pre-release, the release branch should also build daily to catch any updates.

### Changelog entry

N/A
